### PR TITLE
Change from versioningit to static version numbers

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -29,9 +29,8 @@ jobs:
         run: |
           # set up environment
           cd conda.recipe
-          echo "versioningit $(versioningit ../)"
           # build the package - need experimental feature of loading data from pyproject.toml
-          VERSION=$(versioningit ../) rattler-build build -c conda-forge -c mantid --experimental -r .
+          rattler-build build -c conda-forge -c mantid --experimental -r .
       - name: upload conda package to anaconda
         shell: pixi run bash -e {0}
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 src/mantidprofiler.egg-info/
-src/mantidprofiler/_version.py
 src/mantidprofiler/__pycache__/
 # pixi environments
 .pixi/*

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ You can interact with a demo profile [here](http://www.nbi.dk/~nvaytet/SNSPowder
 - `--bytes`               Report disk speed in GBps rather than Gbps (default: False)
 - `--mintime MINTIME`    minimum duration for an algorithm to appear inthe profiling graph (in seconds). (default: 0.1)
 
+## Notes for developers
+
+The version number for releases is stored in `pyproject.toml` and everything else reads this information.
+To change the version number for a release, either edit the file by hand or `pixi project version minor` to bump the minor version number.
+
 ## Similar projects
 
 [viztracer](https://github.com/gaogaotiantian/viztracer) creates similar information for generic python software

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -1,5 +1,4 @@
 # load information from pyproject.toml
-# this will get the version set by environment variable
 # change the build number by hand if you want to rebuild the package
 schema_version: 1
 
@@ -24,12 +23,10 @@ requirements:
   host:
     - pip
     - python
-    - versioningit
     - setuptools>=42
     - wheel
   build:
     - setuptools>=42
-    - versioningit
   run:
     - mantid>6.10 # only framework
     - python

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -4,7 +4,7 @@
 schema_version: 1
 
 context:
-  version: ${{ env.get('VERSION', default='0.0.0') }}
+  version: ${{ load_from_file("../pyproject.toml").project.version }}
   build_number: 0
 
 package:

--- a/pixi.lock
+++ b/pixi.lock
@@ -6,6 +6,8 @@ environments:
     - url: https://conda.anaconda.org/mantid/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -200,7 +202,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py311hdf67eae_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.14-h69e2008_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/versioningit-3.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-filename-1.4.2-pyhe01879c_1.conda
@@ -1803,10 +1804,9 @@ packages:
   timestamp: 1761151594606
 - pypi: ./
   name: mantidprofiler
-  version: 1.1+d20260123
-  sha256: 4892189f2415555c3bbfca6506f8215ceb926ef25543ee65679c1222c3738ca6
+  version: '1.1'
+  sha256: de89888a0b0ad4ddbf879b20268ce33031a699277ef56032f48607bdd936ba34
   requires_python: '>=3.10'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
   sha256: 7b1da4b5c40385791dbc3cc85ceea9fad5da680a27d5d3cb8bfaa185e304a89e
   md5: 5b5203189eb668f042ac2b0826244964
@@ -2827,20 +2827,6 @@ packages:
   - pkg:pypi/urllib3?source=compressed-mapping
   size: 102842
   timestamp: 1765719817255
-- conda: https://conda.anaconda.org/conda-forge/noarch/versioningit-3.3.0-pyhd8ed1ab_0.conda
-  sha256: 4b9a3f6738ab6e241b12b2fe9258f7e051678b911ca0f0ab042becc29096ff51
-  md5: 57b96d99ac0f5a548f7001618db6a561
-  depends:
-  - importlib-metadata >=3.6
-  - packaging >=17.1
-  - python >=3.9
-  - tomli >=1.2,<3.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/versioningit?source=hash-mapping
-  size: 167034
-  timestamp: 1751113901223
 - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
   sha256: 77193c99c6626c58446168d3700f9643d8c0dab1f6deb6b9dd039e6872781bfb
   md5: cfccfd4e8d9de82ed75c8e2c91cab375

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mantidprofiler"
 description = "Uses psrecord and plotly.js to profile a mantid workflow"
-dynamic = ["version"]
+version = "1.1"
 requires-python = ">=3.10"
 readme = "README.md"
 license = { text = "GPL-3.0-or-later" }
@@ -15,7 +15,7 @@ issues = "https://github.com/mantidproject/mantid-profiler/issues"
 mantidprofiler = "mantidprofiler.mantidprofiler:main"
 
 [build-system]
-requires = ["setuptools", "wheel", "toml", "versioningit"]
+requires = ["setuptools", "wheel", "toml"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
@@ -24,23 +24,10 @@ where = ["src"]
 [tool.setuptools.package-data]
 "*" = ["*.yml","*.yaml","*.ini"]
 
-[tool.versioningit.vcs]
-method = "git"
-default-tag = "0.0.1"
-
-[tool.versioningit.next-version]
-method = "minor"
-
-[tool.versioningit.format]
-distance = "{next_version}.dev{distance}"
-dirty = "{version}+d{build_date:%Y%m%d}"
-distance-dirty = "{next_version}.dev{distance}+d{build_date:%Y%m%d%H%M}"
-
-[tool.versioningit.write]
-file = "src/mantidprofiler/_version.py"
-
 [tool.ruff]
 line-length = 120
+
+[tool.ruff.lint]
 # https://beta.ruff.rs/docs/rules/
 select = ["A", "ARG", "BLE", "E", "F", "I", "PT"]
 
@@ -69,7 +56,6 @@ setuptools = "*"
 libarchive = "*"
 pre-commit = "*"
 toml = "*"
-versioningit = "*"
 wheel = "*"
 
 [tool.pixi.environments]

--- a/src/mantidprofiler/__init__.py
+++ b/src/mantidprofiler/__init__.py
@@ -1,0 +1,4 @@
+from importlib import metadata
+
+__version__ = metadata.version("mantidprofiler")
+del metadata

--- a/src/mantidprofiler/__main__.py
+++ b/src/mantidprofiler/__main__.py
@@ -1,4 +1,0 @@
-from mantidprofiler.mantidprofiler import main
-
-if __name__ == "__main__":
-    main()

--- a/src/mantidprofiler/mantidprofiler.py
+++ b/src/mantidprofiler/mantidprofiler.py
@@ -17,7 +17,6 @@
 # PYTHON_ARGCOMPLETE_OK
 
 import argparse
-import sys
 from pathlib import Path
 from threading import Thread
 
@@ -25,6 +24,7 @@ import argcomplete
 import numpy as np
 
 import mantidprofiler.algorithm_tree as at
+from mantidprofiler import __version__
 from mantidprofiler.diskrecord import monitor as diskmonitor
 from mantidprofiler.diskrecord import parse_log as parse_disk_log
 from mantidprofiler.psrecord import monitor as cpumonitor
@@ -273,7 +273,7 @@ def htmlProfile(
 
 
 # Main function to launch process monitor and create interactive HTML plot
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Profile a Mantid workflow", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
@@ -315,9 +315,11 @@ def main():
         help="minimum duration for an algorithm to appear in the profiling graph (in seconds).",
     )
 
+    parser.add_argument("--version", action="version", version=f"mantidprofiler {__version__}")
+
     # parse command line arguments
     argcomplete.autocomplete(parser)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)  # allow getting them supplied to `main()` in tests
 
     print(f"Attaching to process {args.pid}")
 
@@ -391,7 +393,3 @@ def main():
         header=header,
         html_height=args.height,
     )
-
-
-if __name__ == "__main__":
-    sys.exit(main())


### PR DESCRIPTION
For a simple project, static version numbers are much easier to maintain than updating the configuration for versioningit and working around the fact that conda/pixi don't play nice with dynamic version numbers.