### PR TITLE
Fix mantid run constraint

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,7 +30,7 @@ jobs:
           # set up environment
           cd conda.recipe
           # build the package - need experimental feature of loading data from pyproject.toml
-          rattler-build build -c conda-forge -c mantid --experimental -r .
+          rattler-build build --experimental -r .
       - name: upload conda package to anaconda
         shell: pixi run bash -e {0}
         if: startsWith(github.ref, 'refs/tags/v')

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 context:
   version: ${{ load_from_file("../pyproject.toml").project.version }}
-  build_number: 0
+  build_number: 1
 
 package:
   name: mantidprofiler
@@ -31,7 +31,7 @@ requirements:
     - python
     - argcomplete
     - psutil>=5.8.0
-  run_exports:
+  run_constraints:
     - mantid>6.10 # only framework
 tests:
   - python:

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -15,7 +15,6 @@ source:
 
 build:
   number: ${{ build_number }}
-  string: py${{py}}
   noarch: python
   script: ${{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
 


### PR DESCRIPTION
mantid was previously in the `run_exports` section, which meant "if mantid-profiler is in the build or host environment, install mantid>6.10"

What we really want is "if we want to install mantid alongside mantid-profiler, it must be mantid>6.10. This is achieved via `run_contraints`.